### PR TITLE
Aが選択される確率を0に

### DIFF
--- a/src/components/DropZone.vue
+++ b/src/components/DropZone.vue
@@ -35,7 +35,7 @@ export default {
   },
   methods: {
     generate () {
-      const c = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
+      const c = ['B', 'C', 'D', 'E', 'E', 'F', 'G', 'H']
       var tx = Math.floor(Math.random() * 8)
       var y = Math.floor(Math.random() * 8 + 1)
       var dz = c[tx] + y


### PR DESCRIPTION
Aを含む落下地点は海の上でゲームとしてなりたたないため
Aの出る確率を0にして、Eの確率を増やした